### PR TITLE
Fixing local grading to sync with autograder

### DIFF
--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -17,128 +17,128 @@ unit sc = testGroup "NANO"
   [ scoreTest ( uncurry Nano.lookupId
               , ("z1", Nano.env0)
               , (Nano.VInt 0)
-              , 1
+              , 5
               , "lookup1")
   , scoreTest ( uncurry Nano.lookupId
               ,  ("x", Nano.env0)
               , (Nano.VInt 1)
-              , 1
+              , 5
               , "lookup2")
   , scoreTest ( uncurry Nano.eval
               , (Nano.env0, (Nano.EBin Nano.Minus (Nano.EBin Nano.Plus "x" "y") (Nano.EBin Nano.Plus "z" "z1")))
               , (Nano.VInt 0)
-              , 1
+              , 5
               , "eval EBin 1")
   , scoreTest ( uncurry Nano.eval
               , ([],(Nano.EBin Nano.Eq (Nano.EInt 2) (Nano.EInt 3)))
               , (Nano.VBool False)
-              , 1
+              , 5
               , "eval EBin 2")
   , scoreTest ( Nano.eval env1
               , Nano.EVar "c1"
               , Nano.VInt 1
-              , 2
+              , 5
               , "1a - c1")
   , scoreTest ( Nano.eval env1
               , Nano.EBin Nano.Mul
                   ( Nano.EBin Nano.Minus (Nano.EInt 20) (Nano.EVar "c1"))
                   ( Nano.EBin Nano.Plus  (Nano.EVar "c2") (Nano.EVar "c3") )
               , Nano.VInt 95
-              , 3
+              , 5
               , "1a - (20-c1)*(c2+c3)")
   , failTest  ( Nano.eval env2
               , Nano.EBin Nano.Plus (Nano.EVar "bt") (Nano.EVar "c3")
               , "type error"
-              , 1
+              , 6
               , "1b - True + 3")
   , failTest  ( Nano.eval env2
               , Nano.EBin Nano.Or (Nano.EVar "bt") (Nano.EVar "c3")
               , "type error"
-              , 1
+              , 6
               , "1b - bt||c3")
   , scoreTest ( Nano.eval []
               , Nano.ELet "x" (Nano.EInt 4) (Nano.EVar "x")
               , Nano.VInt 4
-              , 1
+              , 6
               , "1c - let x = 4 in x")
   , scoreTest ( Nano.eval []
               , Nano.EApp (Nano.ELam "x" (Nano.EBin Nano.Mul (Nano.EVar "x") (Nano.EVar "x"))) (Nano.EInt 5)
               , Nano.VInt 25
-              , 2
+              , 6
               , "1d - (fun x->x*x) 5")
   , scoreTest ( Nano.eval []
               , Nano.ELet "ksum" (Nano.ELam "x" (Nano.EIf (Nano.EBin Nano.Eq (Nano.EVar "x") (Nano.EInt 0)) (Nano.EInt 0) (Nano.EBin Nano.Plus (Nano.EVar "x") (Nano.EApp (Nano.EVar "ksum") (Nano.EBin Nano.Minus (Nano.EVar "x") (Nano.EInt 1)))))) (Nano.EApp (Nano.EVar "ksum") (Nano.EInt 100))
               , Nano.VInt 5050
-              , 1
+              , 6
               , "1e - eval recursion - ksum") -- sum of first k positive integers
   , scoreTest ( Nano.eval Nano.prelude
               , Nano.ELet "len" (Nano.ELam "x" (Nano.EIf (Nano.EBin Nano.Eq (Nano.EVar "x") Nano.ENil) (Nano.EInt 0) (Nano.EBin Nano.Plus (Nano.EInt 1) (Nano.EApp (Nano.EVar "len") (Nano.EApp (Nano.EVar "tail") (Nano.EVar "x")))))) (Nano.EApp (Nano.EVar "len") (Nano.EBin Nano.Cons (Nano.EInt 5) (Nano.EBin Nano.Cons (Nano.EInt 5) (Nano.EBin Nano.Cons (Nano.EInt 5) (Nano.EBin Nano.Cons (Nano.EInt 5) Nano.ENil)))))
               , Nano.VInt 4
-              , 2
+              , 6
               , "1f - recursion + VPrim, list length") -- length of a list
   , scoreTest ( uncurry Nano.eval
               , (Nano.prelude, (parse "let x = [1,2,3,4] in head (tail x)"))
               , Nano.VInt 2
-              , 1
+              , 6
               , "1f - VPrim 1")
   , scoreTest ( uncurry Nano.eval
               , (Nano.prelude, (parse "let x = [1,2,3,4] in head [2,3]:tail x"))
               , Nano.valueList [Nano.VInt 2, Nano.VInt 2, Nano.VInt 3, Nano.VInt 4]
-              , 1
+              , 6
               , "1f - VPrim 2")
   , scoreTest ( uncurry Nano.eval
               , (Nano.prelude, (parse "let sumList x s = if x == [] then s else sumList (tail x) (s + head x) in sumList [1,2,3,4] 0"))
               , Nano.VInt 10
-              , 2
+              , 6
               , "1e/f - sumList tail recursion") -- sum of a list
   , fileTest  ( "tests/input/t1.hs"
               , Nano.VInt 45
-              , 1 )
+              , 6 )
   , fileTest  ( "tests/input/t2.hs"
               , Nano.VInt 0
-              , 1 )
+              , 6 )
   , fileTest  ( "tests/input/t3.hs"
               , Nano.VInt 2
-              , 1 )
+              , 6 )
   , fileTestE ( "tests/input/t4.hs"
               , "bound"
-              , 1 )
+              , 6 )
   , fileTest  ( "tests/input/t5.hs"
               , Nano.VInt 6
-              , 1 )
+              , 6 )
   , fileTest  ( "tests/input/t6.hs"
               , Nano.VInt 102
-              , 2 )
+              , 6 )
   , fileTest  ( "tests/input/t8.hs"
               , Nano.VInt 55
-              , 2 )
+              , 6 )
   , fileTest  ( "tests/input/t9.hs"
               , Nano.VInt 3628800
-              , 2 )
+              , 6 )
   , fileTest  ( "tests/input/t10.hs"
               , Nano.VInt 110
-              , 2 )
+              , 6 )
   , fileTest  ( "tests/input/t11.hs"
               , Nano.VInt 55
-              , 2 )
+              , 6 )
   , fileTest  ( "tests/input/t12.hs"
               , Nano.VInt 3628800
-              , 2 )
+              , 6 )
   , fileTest  ( "tests/input/t13.hs"
               , Nano.VInt 80
-              , 2 )
+              , 6 )
   , fileTest  ( "tests/input/t14.hs"
               , Nano.valueList [Nano.VInt 1, Nano.VInt 6, Nano.VInt 7, Nano.VInt 8]
-              , 2 )
+              , 6 )
   , fileTest  ( "tests/input/t15.hs"
               , Nano.VBool False
-              , 2 )
+              , 6 )
   , fileTest  ( "tests/input/t16.hs"
               , Nano.valueList [Nano.VInt 2, Nano.VInt 3, Nano.VInt 4, Nano.VInt 5]
-              , 3 )
+              , 6 )
   , fileTest  ( "tests/input/t17.hs"
               , Nano.VInt 10
-              , 3 )
+              , 6 )
   ]
   where
     scoreTest :: (Show b, Eq b) => (a -> b, a, b, Int, String) -> TestTree


### PR DESCRIPTION
Earlier the local tests were graded out of 50 instead of 180. Updated individual test's scores to sync with autograding.json.